### PR TITLE
Add options to configure how MongoDB and NewtonsoftJson (Json.NET) serialization 

### DIFF
--- a/MongoDb.JsonPatchConverter/ConversionResult.cs
+++ b/MongoDb.JsonPatchConverter/ConversionResult.cs
@@ -1,9 +1,15 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using MongoDB.Driver;
 
 namespace MongoDb.JsonPatchConverter
 {
+    /// <summary>
+    /// This object contain various definitions for updating using MongDb Driver, as well as errors occured during the conversion process
+    /// </summary>
+    /// <typeparam name="TOut"></typeparam>
     public class ConversionResult<TOut>
     {
         public ConversionResult()
@@ -13,9 +19,66 @@ namespace MongoDb.JsonPatchConverter
             Errors = new List<OperationError>();
         }
 
+        /// <summary>
+        /// A collection of update definitions
+        /// </summary>
         public ICollection<UpdateDefinition<TOut>> Updates { get; }
+
+        /// <summary>
+        /// A collection of filter definitions
+        /// </summary>
         public ICollection<FilterDefinition<TOut>> Filters { get; }
+
+        /// <summary>
+        /// A collection of error during the conversion process
+        /// </summary>
         public ICollection<OperationError> Errors { get; }
+
+        /// <summary>
+        /// Determine whether the conversion process has any error
+        /// </summary>
         public bool HasErrors => Errors.Any();
+
+        /// <summary>
+        /// Apply the update operations to a collection
+        /// </summary>
+        /// <param name="collection">Collection to apply the update</param>
+        /// <param name="additionalCriteria">Additional filter to apply, eg: match id</param>
+        /// <param name="additionalOperation">Additional update operation to apply, eg: update timestamp</param>
+        /// <exception cref="InvalidOperationException">Trying to apply changes to a error conversion result</exception>
+        /// <returns>The result of an update operation.</returns>
+        public async Task<UpdateResult> Apply(
+            IMongoCollection<TOut> collection, 
+            FilterDefinition<TOut> additionalCriteria,
+            UpdateDefinition<TOut> additionalOperation)
+        {
+            if (HasErrors)
+                throw new InvalidOperationException("Cannot apply changes to an error conversion result!");
+
+            var filters = new List<FilterDefinition<TOut>>(Filters) { additionalCriteria };
+            var updates = new List<UpdateDefinition<TOut>>(Updates) { additionalOperation };
+
+            var finalFilter = filters.AndAll();
+            var finalUpdate = Builders<TOut>.Update.Combine(updates);
+
+            return await collection.UpdateManyAsync(finalFilter, finalUpdate);
+        }
+
+        /// <summary>
+        /// Apply the update operations to a collection
+        /// </summary>
+        /// <param name="collection">Collection to apply the update</param>
+        /// <exception cref="InvalidOperationException">Trying to apply changes to a error conversion result</exception>
+        /// <returns>The result of an update operation.</returns>
+        public async Task<UpdateResult> Apply(IMongoCollection<TOut> collection)
+        {
+            if (HasErrors)
+                throw new InvalidOperationException("Cannot apply changes to an error conversion result!");
+
+            var finalFilter = Filters.AndAll();
+            var finalUpdate = Builders<TOut>.Update.Combine(Updates);
+
+            return await collection.UpdateManyAsync(finalFilter, finalUpdate);
+        }
     }
 }

--- a/MongoDb.JsonPatchConverter/ConverterExtensions.cs
+++ b/MongoDb.JsonPatchConverter/ConverterExtensions.cs
@@ -1,0 +1,84 @@
+﻿using MongoDB.Driver;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MongoDb.JsonPatchConverter
+{
+    public static class ConverterExtensions
+    {
+        /// <summary>
+        /// Scan a type for mapping information
+        /// </summary>
+        /// <typeparam name="T">the type to scan</typeparam>
+        /// <param name="registry"></param>
+        public static void MapType<T>(this IMapRegistry registry) => registry.MapType(typeof(T));
+
+        /// <summary>
+        /// Get mappings of a type
+        /// </summary>
+        /// <typeparam name="T">type to get mapping information</typeparam>
+        /// <param name="registry"></param>
+        /// <returns>A <see cref="IEnumerable{MapDescription}"/> that describes this type</returns>
+        public static IEnumerable<MapDescription> GetMap<T>(this IMapRegistry registry) => registry.GetMap(typeof(T));
+
+        /// <summary>
+        /// Combine all filters with and operation
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="filters"></param>
+        /// <returns>A new <see cref="FilterDefinition{TDocument}"/> that combines all specified filters</returns>
+        public static FilterDefinition<T> AndAll<T>(this IEnumerable<FilterDefinition<T>> filters)
+        {
+            if (filters.Any())
+                return filters.Aggregate((acc, val) => acc & val);
+            else
+                return Builders<T>.Filter.Empty;
+        }
+
+        /// <summary>
+        /// Combine all filters with or operation
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="filters"></param>
+        /// <returns>A new <see cref="FilterDefinition{TDocument}"/> that combines all specified filters</returns>
+        public static FilterDefinition<T> OrAll<T>(this IEnumerable<FilterDefinition<T>> filters)
+        {
+            if (filters.Any())
+                return filters.Aggregate((acc, val) => acc | val);
+            else
+                return Builders<T>.Filter.Empty;
+        }
+
+
+        /// <summary>
+        /// Apply the update operations to a collection
+        /// </summary>
+        /// <typeparam name="T">Type model of the collection</typeparam>
+        /// <param name="col"></param>
+        /// <param name="conversion">The conversion result</param>
+        /// <param name="additionalCriteria">Additional filter to apply, eg: match id</param>
+        /// <param name="additionalOperation">Additional update operation to apply, eg: update timestamp</param>
+        /// <exception cref="InvalidOperationException">Trying to apply changes to a error conversion result</exception>
+        /// <returns>The result of an update operation.</returns>
+        public static async Task<UpdateResult> UpdateManyAsync<T>(
+           this IMongoCollection<T> col,
+           ConversionResult<T> conversion,
+           FilterDefinition<T> additionalCriteria,
+           UpdateDefinition<T> additionalOperation)
+           => await conversion.Apply(col, additionalCriteria, additionalOperation);
+
+        /// <summary>
+        /// Apply the update operations to a collection
+        /// </summary>
+        /// <typeparam name="T">Type model of the collection</typeparam>
+        /// <param name="col"></param>
+        /// <param name="conversion">The conversion result</param>
+        /// <exception cref="InvalidOperationException">Trying to apply changes to a error conversion result</exception>
+        /// <returns>The result of an update operation.</returns>
+        public static async Task<UpdateResult> UpdateManyAsync<T>(this IMongoCollection<T> col, ConversionResult<T> conversion)
+            => await conversion.Apply(col);
+    }
+}

--- a/MongoDb.JsonPatchConverter/IMapRegistry.cs
+++ b/MongoDb.JsonPatchConverter/IMapRegistry.cs
@@ -3,9 +3,22 @@ using System.Collections.Generic;
 
 namespace MongoDb.JsonPatchConverter
 {
+    /// <summary>
+    /// Contains information about types to aid with converting
+    /// </summary>
     public interface IMapRegistry
     {
-        void MapType<T>() where T : class;
+        /// <summary>
+        /// Scan a type for mapping information
+        /// </summary>
+        /// <param name="type">the type to scan</param>
+        void MapType(Type type);
+
+        /// <summary>
+        /// Get mappings of a type
+        /// </summary>
+        /// <param name="t">type to get mapping information</param>
+        /// <returns>A <see cref="IEnumerable{MapDescription}"/> that describes this type</returns>
         IEnumerable<MapDescription> GetMap(Type t);
     }
 }

--- a/MongoDb.JsonPatchConverter/JsonPatchConverter.cs
+++ b/MongoDb.JsonPatchConverter/JsonPatchConverter.cs
@@ -9,6 +9,9 @@ using Newtonsoft.Json;
 
 namespace MongoDb.JsonPatchConverter
 {
+    /// <summary>
+    /// Convert <see cref="JsonPatchDocument"/> to MongoDB update query
+    /// </summary>
     public class JsonPatchConverter : IJsonPatchConverter
     {
         private const string OperationNotSupportedFormat = "Operation '{0}' is not supported.";
@@ -34,7 +37,9 @@ namespace MongoDb.JsonPatchConverter
         public JsonSerializerSettings SerializerSettings { get; } = new JsonSerializerSettings();
         public Action<BsonDeserializationContext.Builder> DeserializationConfig { get; } = x => { };
 
-
+        /// <summary>
+        /// Instanciate <see cref="JsonPatchConverter"/> with custom serializer and deserializer settings
+        /// </summary>
         public JsonPatchConverter(
             IMapRegistry mapRegistry, 
             JsonSerializerSettings serializerSettings,
@@ -45,13 +50,39 @@ namespace MongoDb.JsonPatchConverter
             DeserializationConfig = deserializationConfig;
         }
 
+        /// <summary>
+        /// Instanciate <see cref="JsonPatchConverter"/>
+        /// </summary>
+        /// <param name="mapRegistry"></param>
         public JsonPatchConverter(IMapRegistry mapRegistry)
         {
             MapRegistry = mapRegistry;
         }
 
+        /// <summary>
+        /// Instanciate <see cref="JsonPatchConverter"/> with default <see cref="MongoDb.JsonPatchConverter.MapRegistry"/>
+        /// </summary>
         public JsonPatchConverter() : this(new MapRegistry()) { }
 
+
+        /// <summary>
+        /// Convert <see cref="JsonPatchDocument{TModel}"/> to MongoDb update query
+        /// </summary>
+        /// <typeparam name="TModel"> the json patch model </typeparam>
+        /// <param name="document"> the json patch document </param>
+        /// <returns> A object contains various definitions to update using MongoDb Driver </returns>
+        /// <exception cref="InvalidOperationException">  </exception>
+        public ConversionResult<TModel> Convert<TModel>(JsonPatchDocument<TModel> document) where TModel : class
+            => Convert<TModel, TModel>(document);
+
+        /// <summary>
+        /// Convert <see cref="JsonPatchDocument{TModel}"/> to MongoDb update query, with different model for input and output
+        /// </summary>
+        /// <typeparam name="TOut"> the output model, usually the one used in your database </typeparam>
+        /// <typeparam name="TModel"> the json patch model, eg: a DTO or a projection </typeparam>
+        /// <param name="document"> the json patch document </param>
+        /// <returns> A object contains various definitions to update using MongoDb Driver </returns>
+        /// <exception cref="InvalidOperationException">  </exception>
         public ConversionResult<TOut> Convert<TOut, TModel>(JsonPatchDocument<TModel> document) where TModel : class
         {
             var modelMaps = MapsOrThrow(typeof(TModel));
@@ -194,7 +225,6 @@ namespace MongoDb.JsonPatchConverter
         }
 
       
-
         private static UpdateDefinition<TOut> ConstructTypedSet<TOut>(string path, MapDescription map, object value)
         {
             // TODO add caching
@@ -206,7 +236,5 @@ namespace MongoDb.JsonPatchConverter
 
             return (UpdateDefinition<TOut>)updateDefinition;
         }
-
-      
     }
 }

--- a/MongoDb.JsonPatchConverter/JsonPatchConverter.cs
+++ b/MongoDb.JsonPatchConverter/JsonPatchConverter.cs
@@ -16,7 +16,7 @@ namespace MongoDb.JsonPatchConverter
             "Remove array element by index is not supported https://jira.mongodb.org/browse/SERVER-1014";
         private const string ConversionErrorFormat = "Cannot convert value for property at {0}";
         private const string NoTypeMapFormat = "Type {0} has no registered mappings";
-        private static readonly char[] BadSymbols = {'$', '{', '}', '[', ']'};
+        private static readonly char[] BadSymbols = { '$', '{', '}', '[', ']' };
         private const string PathNotFoundFormat = "Operation '{0}' points to path '{1}' , which is not found on models.";
         private const string FiledMismatchOnTypes = "Model {0} does not have any field, which exist in {1}.";
         private const string OperationUpdateDefinitionTypeName = "MongoDB.Driver.OperatorUpdateDefinition`2";
@@ -24,19 +24,33 @@ namespace MongoDb.JsonPatchConverter
         private static readonly Type OperationUpdateDefinitionType;
         private static readonly Type GenericStringFieldDefinition;
 
-        private readonly MapRegistry _mapRegistry;
-        
-
         static JsonPatchConverter()
         {
             OperationUpdateDefinitionType = typeof(UpdateDefinition<>).Assembly.GetType(OperationUpdateDefinitionTypeName, true);
             GenericStringFieldDefinition = typeof(StringFieldDefinition<int, int>).GetGenericTypeDefinition();
         }
 
-        public JsonPatchConverter(MapRegistry mapRegistry)
+        public IMapRegistry MapRegistry { get; }
+        public JsonSerializerSettings SerializerSettings { get; } = new JsonSerializerSettings();
+        public Action<BsonDeserializationContext.Builder> DeserializationConfig { get; } = x => { };
+
+
+        public JsonPatchConverter(
+            IMapRegistry mapRegistry, 
+            JsonSerializerSettings serializerSettings,
+            Action<BsonDeserializationContext.Builder> deserializationConfig)
         {
-            _mapRegistry = mapRegistry;
+            MapRegistry = mapRegistry;
+            SerializerSettings = serializerSettings;
+            DeserializationConfig = deserializationConfig;
         }
+
+        public JsonPatchConverter(IMapRegistry mapRegistry)
+        {
+            MapRegistry = mapRegistry;
+        }
+
+        public JsonPatchConverter() : this(new MapRegistry()) { }
 
         public ConversionResult<TOut> Convert<TOut, TModel>(JsonPatchDocument<TModel> document) where TModel : class
         {
@@ -60,7 +74,7 @@ namespace MongoDb.JsonPatchConverter
                 switch (op.OperationType)
                 {
                     case OperationType.Add:
-                        HandleAdd(op, matched, path, result);
+                        HandleAdd(op, matched, path, result, SerializerSettings, DeserializationConfig);
                         break;
                     case OperationType.Copy:
                     case OperationType.Move:
@@ -71,7 +85,7 @@ namespace MongoDb.JsonPatchConverter
                         HandleRemove(op, matched, path, result);
                         break;
                     case OperationType.Replace:
-                        HandleReplace(op, matched, path, result);
+                        HandleReplace(op, matched, path, result, SerializerSettings, DeserializationConfig);
                         break;
 
                 }
@@ -84,12 +98,14 @@ namespace MongoDb.JsonPatchConverter
             Operation op,
             MapDescription map,
             string path,
-            ConversionResult<TOut> conversion)
+            ConversionResult<TOut> conversion,
+            JsonSerializerSettings serializerSettings,
+            Action<BsonDeserializationContext.Builder> deserializationConfig)
         {
             var val = op.value;
             try
             {
-                val = ConvertType(map, val);
+                val = ConvertType(map, val, serializerSettings, deserializationConfig);
             }
             catch
             {
@@ -122,7 +138,9 @@ namespace MongoDb.JsonPatchConverter
             Operation operation, 
             MapDescription map, 
             string path,
-            ConversionResult<TOut> conversion)
+            ConversionResult<TOut> conversion,
+            JsonSerializerSettings serializerSettings,
+            Action<BsonDeserializationContext.Builder> deserializationConfig)
         {
             var lastDot = path.LastIndexOf(".", StringComparison.InvariantCulture);
             if (lastDot >0)
@@ -135,7 +153,7 @@ namespace MongoDb.JsonPatchConverter
             object val;
             try
             {
-                val = ConvertType(map, operation.value);
+                val = ConvertType(map, operation.value, serializerSettings, deserializationConfig);
             }
             catch
             {
@@ -148,7 +166,7 @@ namespace MongoDb.JsonPatchConverter
 
         private IEnumerable<MapDescription> MapsOrThrow(Type t)
         {
-            var maps = _mapRegistry.GetMap(t).ToArray();
+            var maps = MapRegistry.GetMap(t).ToArray();
 
             if (maps.Length == 0)
             {
@@ -157,13 +175,17 @@ namespace MongoDb.JsonPatchConverter
             return maps;
         }
 
-        private static object ConvertType(MapDescription map, object value)
+        private static object ConvertType(
+            MapDescription map, 
+            object value, 
+            JsonSerializerSettings serializerSettings,
+            Action<BsonDeserializationContext.Builder> deserializationConfig)
         {
             // Actually, i wanted to implement something cool, but after i saw 
             // https://github.com/aspnet/JsonPatch/blob/98e2d5d4c729770e5e8e146602ab2b6c5bdc439a/src/Microsoft.AspNetCore.JsonPatch/Adapters/ObjectAdapter.cs#L1012
             // i decided, that everything is ok :)
-            var serialized = JsonConvert.SerializeObject(value);
-            return BsonSerializer.Deserialize(serialized, map.Type);
+            var serialized = JsonConvert.SerializeObject(value, serializerSettings);
+            return BsonSerializer.Deserialize(serialized, map.Type, deserializationConfig);
         }
 
         private static bool ContainsBadCharacters(string value)

--- a/MongoDb.JsonPatchConverter/MapRegistry.cs
+++ b/MongoDb.JsonPatchConverter/MapRegistry.cs
@@ -6,6 +6,9 @@ using System.Text.RegularExpressions;
 
 namespace MongoDb.JsonPatchConverter
 {
+    /// <summary>
+    /// Default implementation of <see cref="IMapRegistry"/>
+    /// </summary>
     public class MapRegistry : IMapRegistry
     {
         private readonly ConcurrentDictionary<Type, MapDescription[]> _dictionary;
@@ -16,8 +19,7 @@ namespace MongoDb.JsonPatchConverter
             _dictionary = new ConcurrentDictionary<Type, MapDescription[]>();
         }
 
-        public void MapType<T>() where T : class => MapType(typeof(T));
-
+        /// <inheritdoc/>
         public void MapType(Type type)
         {
             if (type == typeof(string))
@@ -32,8 +34,7 @@ namespace MongoDb.JsonPatchConverter
             _dictionary.AddOrUpdate(type, valueFactory, (a, b) => b);
         }
 
-        public IEnumerable<MapDescription> GetMap<T>() => GetMap(typeof(T));
-
+        /// <inheritdoc/>
         public IEnumerable<MapDescription> GetMap(Type t)
         {
             if (!_dictionary.TryGetValue(t, out MapDescription[] map))

--- a/README.md
+++ b/README.md
@@ -1,2 +1,113 @@
+![nuget](https://img.shields.io/nuget/v/MongoDb.JsonPatchConverter)
+
 # MongoDb.JsonPatchConverter
-Simple JsonPatchDocument&lt;T&gt; to FilterDefiniton&lt;T&gt; and UpdateDefinition&lt;T&gt; Converter 
+MongoDb.JsonPatchConverter is a simple library to convert from JsonPatchDocument&lt;T&gt; to FilterDefiniton&lt;T&gt; and UpdateDefinition&lt;T&gt; 
+
+# Installation 
+*Change `<version>` to your version of choice*
+
+Package Manager Console: 
+```
+Install-Package MongoDb.JsonPatchConverter -Version <version>
+```
+
+.NET CLI:
+```
+dotnet add package MongoDb.JsonPatchConverter --version <version>
+```
+
+# Usage
+### First, create an instance of `MongoDb.JsonPatchConverter.JsonPatchConverter`
+```cs
+using MongoDb.JsonPatchConverter;
+
+...
+
+var converter = new JsonPatchConverter();
+```
+Or, if you prefer the ASP.NET Core way:
+
+```cs
+var builder = WebApplication.CreateBuilder(args);
+builder.Services.AddSingleton<JsonPatchConverter>();
+
+...
+```
+
+### Using the converter in a controller:
+```cs
+[ApiController]
+public class SampleController : ControllerBase
+{
+  private readonly JsonPatchConverter _converter;
+  private readonly IMongoCollection<Sample> _samples;
+  
+  public SampleController(JsonPatchConverter converter, IMongoCollection<Sample> samples) 
+  {
+    _converter = converter;
+    _smaples = samples;
+  }
+
+  [HttpPatch]
+  public async Task<IActionResult> Modify([FromBody] JsonPatchDocument<Sample> descriptor)
+  {
+      await _converter.Convert(descriptor).Apply(_samples);
+      return NoContent();
+  }
+}
+```
+
+If you are using different model for `JsonPatchDocument` and your underlying database, such as Data Transfer Objects (DTOs), you can specify additional type parameters in `Apply<TOut, TModel>(...)`
+```cs
+...
+
+[HttpPatch]
+public async Task<IActionResult> Modify([FromBody] JsonPatchDocument<SampleDTO> descriptor)
+{
+    await _converter.Convert<Sample, SampleDTO>(descriptor).Apply(_samples);
+    return NoContent();
+}
+```
+
+
+The above example will convert a `JsonPatchDocument<Sample>` and apply the changes to the `_sample` collection. However, if you need to define additional filter and operation, you can use another overload of `Apply(...)`, the example below will include a id match, userid match and update the timestamp upon updating the document:
+```cs
+... 
+
+[HttpPatch]
+public async Task<IActionResult> Modify([FromRoute] string id, [FromQuery] string userId, [FromBody] JsonPatchDocument<Sample> descriptor)
+{
+    var filter = Builders<Sample>.Filter.Eq(x => x.Id, id) & Builders<Sample>.Filter.Eq(x => x.UserId, userId);
+    var update = Builders<Sample>.Update.Set(x => x.Timestamp, DateTime.UtcNow);
+    await _converter.Convert(descriptor).Apply(_samples, filter, update);
+    return NoContent();
+}
+```
+
+If you want to get the definitions, it is located in `Filters` and `Updates` properties of `ConversionResult<TOut>`
+```cs
+...
+
+var result = _converter.Convert(descriptor);
+var filterDef = result.Filters;
+var updateDef = result.Updates;
+// Do something with these definitions
+
+...
+```
+
+# Configuration
+### Cammel case field serializer
+
+You can define serialize and deserialize configuration in `JsonPatchConverter` constructor: 
+```cs
+var serializeConfig = new JsonSerializerSettings 
+{ 
+    ContractResolver = new CamelCasePropertyNamesContractResolver() 
+};
+
+var converter = new JsonPatchConverter(new MapRegistry(), serializeConfig, x => {});
+```
+
+# License
+This project is licensed under the [MIT License](https://opensource.org/licenses/MIT). Please refer to the terms in the `LICENSE` file included in the repository.

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ public async Task<IActionResult> Modify([FromBody] JsonPatchDocument<SampleDTO> 
 }
 ```
 
-
+### Advance usages
 The above example will convert a `JsonPatchDocument<Sample>` and apply the changes to the `_sample` collection. However, if you need to define additional filter and operation, you can use another overload of `Apply(...)`, the example below will include a id match, userid match and update the timestamp upon updating the document:
 ```cs
 ... 


### PR DESCRIPTION
Includes MongoDB and NewtonsoftJson (Json.NET) serialization config at `JsonPatchConverter`. MapRegistry will also implicitly map Type on method calls. I also added a few quality of life helper methods to reduce the code required to convert and apply the change to the collection and add some documentation to help new users get a hang of the library